### PR TITLE
check for mobile device browsers before using touch events

### DIFF
--- a/src/js/pick-a-color.js
+++ b/src/js/pick-a-color.js
@@ -11,17 +11,20 @@
       // capabilities
 
       var supportsTouch = 'ontouchstart' in window,
+          mobileDevice = ( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) ? true : false,
           smallScreen = (parseInt($(window).width(),10) < 767) ? true : false,
           supportsLocalStorage = 'localStorage' in window && window.localStorage !== null &&
             typeof JSON === 'object', // don't use LS if JSON is not available
           isIELT10 = document.all && !window.atob, // OH NOES!
 
-          startEvent    = supportsTouch ? "touchstart.pickAColor"  : "mousedown.pickAColor",
-          moveEvent     = supportsTouch ? "touchmove.pickAColor"   : "mousemove.pickAColor",
-          endEvent      = supportsTouch ? "touchend.pickAColor"    : "mouseup.pickAColor",
-          clickEvent    = supportsTouch ? "touchend.pickAColor"    : "click.pickAColor",
+          startEvent    = (supportsTouch && mobileDevice) ? "touchstart.pickAColor"  : "mousedown.pickAColor",
+          moveEvent     = (supportsTouch && mobileDevice) ? "touchmove.pickAColor"   : "mousemove.pickAColor",
+          endEvent      = (supportsTouch && mobileDevice) ? "touchend.pickAColor"    : "mouseup.pickAColor",
+          clickEvent    = (supportsTouch && mobileDevice) ? "touchend.pickAColor"    : "click.pickAColor",
           dragEvent     = "dragging.pickAColor",
           endDragEvent  = "endDrag.pickAColor";
+
+
 
       // settings
 


### PR DESCRIPTION
Another solution may be more efficient, but the problem is that windows machines with touchscreens can't use the mouse to control pick-a-color in chrome; only the touchscreen input is recognized.

Windows touchscreens also send equivalent mouse events, so one of the easiest ways to filter out windows touchscreens was to check for mobile user agents.

I tried asking jquery to listen to both mouse and touch events, but pick-a-color still doesn't work as both events are sent simultaneously, effectively opening and immediately closing the picker window.

Any other suggestions for letting windows users use both mouse and touchscreens?
