### PR TITLE
fixes #47, adding an option that can turn off the focusing abilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ $(".pick-a-color").pickAColor({
         showAdvanced          : true,
         showBasicColors       : true,
         showHexInput          : true,
+        allowHexFocus         : true,
         allowBlank            : true
  });
 ```
@@ -244,6 +245,10 @@ Specifies whether or not the dropdown should show a list of basic colors that th
 #### showHexInput
 
 Specifies whether or not to show the hex text input. If false the input has an input type of 'hidden'. Thanks to [Ryan Johnson](https://github.com/rsjohnson) for adding this feature!
+
+#### allowHexFocus
+
+Specifies whether or not focusing in the hex text input will show the dropdown menu. Thanks to [weisjohn](https://github.com/weisjohn) for adding this feature!
 
 #### allowBlank
 

--- a/src/js/pick-a-color.js
+++ b/src/js/pick-a-color.js
@@ -33,6 +33,7 @@
         showAdvanced          : true,
         showBasicColors       : true,
         showHexInput          : true,
+        allowHexFocus         : true,
         allowBlank            : false,
         inlineDropdown        : false,
         basicColors           : {
@@ -1002,30 +1003,33 @@
         //input field focus: clear content
         // input field blur: update preview, restore previous content if no value entered
 
-        myElements.thisEl.focus(function () {
-          var $thisEl = $(this);
-          myColorVars.typedColor = $thisEl.val(); // update with the current
-          if (!settings.allowBlank) {
-            $thisEl.val(""); //clear the field on focus
-          }
-          methods.toggleDropdown(myElements.colorPreviewButton,myElements.ColorMenu);
-        }).blur(function () {
-          var $thisEl = $(this);
-          myColorVars.newValue = $thisEl.val(); // on blur, check the field's value
-          // if the field is empty, put the original value back in the field
-          if (myColorVars.newValue.match(/^\s+$|^$/)) {
+
+        if (settings.allowHexFocus) {
+          myElements.thisEl.focus(function () {
+            var $thisEl = $(this);
+            myColorVars.typedColor = $thisEl.val(); // update with the current
             if (!settings.allowBlank) {
-              $thisEl.val(myColorVars.typedColor);
+              $thisEl.val(""); //clear the field on focus
             }
-          } else { // otherwise...
-            myColorVars.newValue = tinycolor(myColorVars.newValue).toHex(); // convert to hex
-            $thisEl.val(myColorVars.newValue); // put the new value in the field
-            // save to saved colors
-            methods.addToSavedColors(myColorVars.newValue,mySavedColorsInfo,myElements.savedColorsContent);
-          }
-          methods.toggleDropdown(myElements.colorPreviewButton,myElements.ColorMenu);
-          methods.updatePreview($thisEl); // update preview
-        });
+            methods.toggleDropdown(myElements.colorPreviewButton,myElements.ColorMenu);
+          }).blur(function () {
+            var $thisEl = $(this);
+            myColorVars.newValue = $thisEl.val(); // on blur, check the field's value
+            // if the field is empty, put the original value back in the field
+            if (myColorVars.newValue.match(/^\s+$|^$/)) {
+              if (!settings.allowBlank) {
+                $thisEl.val(myColorVars.typedColor);
+              }
+            } else { // otherwise...
+              myColorVars.newValue = tinycolor(myColorVars.newValue).toHex(); // convert to hex
+              $thisEl.val(myColorVars.newValue); // put the new value in the field
+              // save to saved colors
+              methods.addToSavedColors(myColorVars.newValue,mySavedColorsInfo,myElements.savedColorsContent);
+            }
+            methods.toggleDropdown(myElements.colorPreviewButton,myElements.ColorMenu);
+            methods.updatePreview($thisEl); // update preview
+          });
+        }
 
         // toggle visibility of dropdown menu when you click or press the preview button
         methods.executeUnlessScrolled.apply(myElements.colorPreviewButton,


### PR DESCRIPTION
I added an option `allowHexFocus` and documented it's purpose. By using this option, users can overcome #47.  I attempted to maintain documentation style and nomenclature.
