### PR TITLE
Color preview update on manual color change

### DIFF
--- a/src/js/pick-a-color.js
+++ b/src/js/pick-a-color.js
@@ -274,6 +274,11 @@
           if (!settings.showHexInput) {
             $thisEl.attr("type","hidden");
           }
+
+          // track value changes, updating the preview etc
+          $thisEl.change(function() {
+            methods.updatePreview($thisEl);
+          });
         },
 
         updatePreview: function ($thisEl) {
@@ -677,7 +682,6 @@
           selectedColor = tinycolor(selectedColor).toHex();
           $(myElements.thisEl).val(selectedColor);
           $(myElements.thisEl).trigger("change");
-          methods.updatePreview(myElements.thisEl);
           methods.addToSavedColors(selectedColor,mySavedColorsInfo,myElements.savedColorsContent);
           methods.closeDropdown(myElements.colorPreviewButton,myElements.colorMenu); // close the dropdown
         },
@@ -1137,7 +1141,6 @@
             var selectedColor = tinycolor($(this).css("background-color")).toHex();
             $(myElements.thisEl).val(selectedColor);
             $(myElements.thisEl).trigger("change");
-            methods.updatePreview(myElements.thisEl);
             methods.addToSavedColors(selectedColor,mySavedColorsInfo,myElements.savedColorsContent);
             methods.closeDropdown(myElements.colorPreviewButton,myElements.colorMenu); // close the dropdown
           });
@@ -1160,7 +1163,6 @@
                 $thisEl.attr("class").split("#")[1];
               $(myElements.thisEl).val(selectedColor);
               $(myElements.thisEl).trigger("change");
-              methods.updatePreview(myElements.thisEl);
               methods.closeDropdown(myElements.colorPreviewButton,myElements.colorMenu);
               methods.addToSavedColors(selectedColor,mySavedColorsInfo,myElements.savedColorsContent);
             }


### PR DESCRIPTION
This proposed change allows code using pick-a-color to make a color change directly on the color input element and then trigger a change event to force the preview update e.g.

```
input.val('#808080');
input.change();
```
